### PR TITLE
1. Change request

### DIFF
--- a/db/models/User.ts
+++ b/db/models/User.ts
@@ -12,6 +12,7 @@ import { Company } from './Company';
 export enum UserRole {
   accountant = 'accountant',
   corporateSecretary = 'corporateSecretary',
+  director = 'Director',
 }
 
 @Table({ tableName: 'users' })

--- a/src/tickets/tickets.service.spec.ts
+++ b/src/tickets/tickets.service.spec.ts
@@ -111,8 +111,9 @@ describe('TicketsService', () => {
       })
       it('should create Corporate category when type is registrationAddressChange', async () => {
         const companyId = 1;
-        const user = { id: 1, role: 'accountant' };
+        const user = { id: 1, role: UserRole.accountant };
         mockUserModel.findAll = jest.fn().mockResolvedValue([user]);
+        mockTicketModel.findAll = jest.fn().mockResolvedValue([]);
         const type = TicketType.registrationAddressChange;
         const category = TicketCategory.corporate;
         await service.create(type, companyId);
@@ -144,6 +145,7 @@ describe('TicketsService', () => {
         const userRole = UserRole.corporateSecretary;
         const user = { id: 1, role: userRole };
         mockUserModel.findAll = jest.fn().mockResolvedValue([user]);
+        mockTicketModel.findAll = jest.fn().mockResolvedValue([]);
         const type = TicketType.registrationAddressChange;
         await service.create(type, companyId);
         expect(mockUserModel.findAll).toHaveBeenCalledWith({

--- a/src/tickets/tickets.service.spec.ts
+++ b/src/tickets/tickets.service.spec.ts
@@ -152,7 +152,7 @@ describe('TicketsService', () => {
         });
       })
     })
-    describe('findAll user', () => {
+    describe('finding user', () => {
       it('should throw ConflictException if no user found', async () => {
         const companyId = 1;
         const type = TicketType.managementReport;

--- a/src/tickets/tickets.service.spec.ts
+++ b/src/tickets/tickets.service.spec.ts
@@ -171,5 +171,19 @@ describe('TicketsService', () => {
         );
       })
     })
+    describe('with duplicate', () => {
+      it('should throw duplication error if registrationAddressChange exists', async () => {
+        const companyId = 1;
+        const type = TicketType.registrationAddressChange;
+        const user = { id: 1, role: UserRole.corporateSecretary };
+        mockTicketModel.findAll = jest.fn().mockResolvedValue([{ type, companyId }]);
+        await expect(service.create(type, companyId)).rejects.toThrow(
+          new ConflictException(`Ticket of type ${type} already exists for this company`),
+        );
+        expect(mockTicketModel.findAll).toHaveBeenCalledWith(expect.objectContaining({
+          where: { type, companyId },
+        }));
+      })
+    })
   })
 });

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -51,10 +51,20 @@ export class TicketsService {
         ? UserRole.accountant
         : UserRole.corporateSecretary;
 
-    const assignees = await this.userModel.findAll({
+    let assignees = await this.userModel.findAll({
       where: { companyId, role: userRole },
       order: [['createdAt', 'DESC']],
     });
+    
+    if (type === TicketType.registrationAddressChange) {
+      // If no corporate secretary, assign a director
+      if (!assignees.length) {
+        assignees = await this.userModel.findAll({
+          where: { companyId, role: UserRole.director },
+          order: [['createdAt', 'DESC']],
+        });
+      }
+    }
 
     if (!assignees.length)
       throw new ConflictException(

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -29,6 +29,18 @@ export class TicketsService {
       throw new ConflictException(`Invalid ticket type: ${type}`);
     }
 
+    // Validate if registrationAddress is existed for this company
+    if (type === TicketType.registrationAddressChange) {
+      const ticketsResult = await this.ticketModel.findAll({
+        where: { companyId, type: TicketType.registrationAddressChange },
+      });
+      if (ticketsResult.length > 0) {
+        throw new ConflictException(
+          `Ticket of type ${type} already exists for this company`,
+        );
+      }
+    }
+
     const category =
       type === TicketType.managementReport
         ? TicketCategory.accounting


### PR DESCRIPTION
# Summary
Improves the ticket assignment process for registration address change requests:

- Prevents duplicate `registrationAddressChange` tickets for the same company.
- Adds the "Director" user role to the system.
- Implements logic to assign the ticket to a Director if no Corporate Secretary is available.


This change is following #1 

# Approach
Since we have Unit test in place, I used TDD approach to implement this.
See the commits. I wrote the test, test fail, wrote code, test pass, repeat.

# Usage of AI
AI is used on both writing the test case and writing the code.
I used Github CoPilot
