### PR TITLE
2. New Ticket: Adds strike-off ticket type

### DIFF
--- a/db/models/Ticket.ts
+++ b/db/models/Ticket.ts
@@ -18,12 +18,13 @@ export enum TicketStatus {
 export enum TicketType {
   managementReport = 'managementReport',
   registrationAddressChange = 'registrationAddressChange',
+  strikeOff = 'strikeOff',
 }
 
 export enum TicketCategory {
   accounting = 'accounting',
   corporate = 'registrationAddressChange',
-  management = 'management',
+  management = 'Management',
 }
 
 @Table({ tableName: 'tickets' })

--- a/src/tickets/tickets.service.spec.ts
+++ b/src/tickets/tickets.service.spec.ts
@@ -218,6 +218,16 @@ describe('TicketsService', () => {
           new ConflictException(`Multiple users with role ${UserRole.director}. Cannot create a ticket`),
         );
       })
+      it('to call _resolveAllTickets function', async () => {
+        const companyId = 99;
+        const type = TicketType.strikeOff;
+        const user = { id: 8, role: UserRole.director };
+        mockUserModel.findAll = jest.fn().mockResolvedValue([user]);
+        const resolveAllTicketsMock = jest.spyOn(service, '_resolveAllTickets')
+        resolveAllTicketsMock.mockResolvedValue();
+        await service.create(type, companyId);
+        expect(resolveAllTicketsMock).toHaveBeenCalledWith(companyId);
+      })
     })
   })
   describe('_resolveAllTickets', () => {

--- a/src/tickets/tickets.service.spec.ts
+++ b/src/tickets/tickets.service.spec.ts
@@ -205,5 +205,19 @@ describe('TicketsService', () => {
         }));
       })
     })
+    describe('type strikeOff', () => {
+      it('throw error if multiple directors exists', async () => {
+        const companyId = 1;
+        const type = TicketType.strikeOff;
+        const users = [
+          { id: 1, role: UserRole.director },
+          { id: 2, role: UserRole.director },
+        ];
+        mockUserModel.findAll = jest.fn().mockResolvedValue(users);
+        await expect(service.create(type, companyId)).rejects.toThrow(
+          new ConflictException(`Multiple users with role ${UserRole.director}. Cannot create a ticket`),
+        );
+      })
+    })
   })
 });

--- a/src/tickets/tickets.service.spec.ts
+++ b/src/tickets/tickets.service.spec.ts
@@ -220,4 +220,20 @@ describe('TicketsService', () => {
       })
     })
   })
+  describe('_resolveAllTickets', () => {
+    it('should resolve all tickets', async () => {
+      const companyId = 33;
+      const mockTickets = [
+        { id: 1, companyId, type: TicketType.managementReport, status: TicketStatus.open, category: TicketCategory.accounting, save: jest.fn() },
+        { id: 2, companyId, type: TicketType.registrationAddressChange, status: TicketStatus.open, category: TicketCategory.corporate, save: jest.fn() },
+      ];
+      mockTicketModel.findAll = jest.fn().mockResolvedValue(mockTickets);
+
+      await service._resolveAllTickets(companyId);
+      for (const ticket of mockTickets) {
+        expect(ticket.status).toBe(TicketStatus.resolved);
+        expect(ticket.save).toHaveBeenCalled();
+      }
+    });
+  })
 });

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -103,4 +103,8 @@ export class TicketsService {
       status: TicketStatus.open,
     });
   }
+
+  async _resolveAllTickets(companyId: number): Promise<void> {
+    
+  }
 }

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -49,7 +49,9 @@ export class TicketsService {
     const userRole =
       type === TicketType.managementReport
         ? UserRole.accountant
-        : UserRole.corporateSecretary;
+        : TicketType.strikeOff ?
+            UserRole.director :
+            UserRole.corporateSecretary;
 
     let assignees = await this.userModel.findAll({
       where: { companyId, role: userRole },
@@ -63,6 +65,15 @@ export class TicketsService {
           where: { companyId, role: UserRole.director },
           order: [['createdAt', 'DESC']],
         });
+      }
+    }
+
+    if (type === TicketType.strikeOff) {
+        // if multiple directors exist, throw an error
+      if (assignees.length > 1) {
+        throw new ConflictException(
+          `Multiple users with role ${UserRole.director}. Cannot create a ticket`,
+        );
       }
     }
 

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -105,6 +105,13 @@ export class TicketsService {
   }
 
   async _resolveAllTickets(companyId: number): Promise<void> {
-    
+    const tickets = await this.ticketModel.findAll({
+      where: { companyId, status: TicketStatus.open },
+    });
+
+    for (const ticket of tickets) {
+      ticket.status = TicketStatus.resolved;
+      await ticket.save();
+    }
   }
 }

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -94,6 +94,10 @@ export class TicketsService {
       );
 
     const assignee = assignees[0];
+    
+    if (type === TicketType.strikeOff) {
+      await this._resolveAllTickets(companyId);
+    }
 
     return this.ticketModel.create({
       companyId,

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -46,12 +46,18 @@ export class TicketsService {
         ? TicketCategory.accounting
         : TicketCategory.corporate;
 
-    const userRole =
-      type === TicketType.managementReport
-        ? UserRole.accountant
-        : TicketType.strikeOff ?
-            UserRole.director :
-            UserRole.corporateSecretary;
+    let userRole: UserRole;
+    switch (type) {
+      case TicketType.managementReport:
+        userRole = UserRole.accountant;
+        break;
+      case TicketType.registrationAddressChange:
+        userRole = UserRole.corporateSecretary;
+        break;
+    case TicketType.strikeOff:
+        userRole = UserRole.director;
+        break;
+    }   
 
     let assignees = await this.userModel.findAll({
       where: { companyId, role: userRole },


### PR DESCRIPTION
# Summary
Adds the ability to create strike-off tickets.

Key changes:
- Introduces a new `strikeOff` ticket type with associated logic for director assignment and conflict resolution.
- Ensures that only one director is assigned to a `strikeOff` ticket.
- Add another function to resolve all opening tickets
- Automatically resolves all existing open tickets for a company when a `strikeOff` ticket is created.

# Approach
TDD Approach. Tests were written before code

# AI Usage
Github CoPilot was used to suggest almost all test case and code

# Improvement
The service `create` function becomes large and long. Adding another ticket type introduce confusion. Here are some improvement we can comeback to revisit:

- [ ] Organize code so that it resolve 1 ticket type with only 1 switch case